### PR TITLE
Solve decoding issues in csv2cmi.py

### DIFF
--- a/csv2cmi.py
+++ b/csv2cmi.py
@@ -448,7 +448,7 @@ sourceDesc = SubElement(fileDesc, 'sourceDesc')
 # filling in correspondance meta-data
 profileDesc = SubElement(teiHeader, 'profileDesc')
 
-with open(args.filename, 'rt') as letterTable:
+with open(args.filename, 'rt', encoding='utf-8') as letterTable:
     # global table
     table = DictReader(letterTable)
     logging.debug('Recognized columns: %s', table.fieldnames)


### PR DESCRIPTION
I had some issues with the character decoding. Since it is said that the input file must be in utf-8 and there is no further decoding argument in open(), *"the file will by default be decoded into unicode using the system default encoding (see locale.getpreferredencoding())"* [https://docs.python.org/3/library/csv.html](https://docs.python.org/3/library/csv.html) which in combination might lead to incompabilities (for instance working on Windows, standard decoding then would be in Cp1252/ANSI instead of UTF-8). Therefore, I would suggest this minor change adding "encoding='utf-8'" just to make sure that the files are read in utf-8 as well.